### PR TITLE
[FIX] hibernate naming strategy 변경

### DIFF
--- a/src/main/java/com/team/piickle/ballot/domain/BallotItem.java
+++ b/src/main/java/com/team/piickle/ballot/domain/BallotItem.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Entity
 public class BallotItem extends BaseEntity {
 
-    @Column(name = "NAME")
+    @Column
     private String name;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/team/piickle/ballot/domain/BallotItem.java
+++ b/src/main/java/com/team/piickle/ballot/domain/BallotItem.java
@@ -12,8 +12,7 @@ import lombok.NoArgsConstructor;
 @Entity
 public class BallotItem extends BaseEntity {
 
-    @Column
-    private String name;
+    @Column private String name;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "BALLOT_TOPIC_ID")

--- a/src/main/java/com/team/piickle/ballot/domain/BallotTopic.java
+++ b/src/main/java/com/team/piickle/ballot/domain/BallotTopic.java
@@ -18,10 +18,10 @@ import lombok.NoArgsConstructor;
 @Entity
 public class BallotTopic extends BaseEntity {
 
-    @Column(name = "TOPIC")
+    @Column
     private String topic;
 
-    @Column(name = "SORT_ORDER")
+    @Column
     private Long order;
 
     @OneToMany(mappedBy = "ballotTopic", cascade = CascadeType.ALL)

--- a/src/main/java/com/team/piickle/ballot/domain/BallotTopic.java
+++ b/src/main/java/com/team/piickle/ballot/domain/BallotTopic.java
@@ -18,11 +18,9 @@ import lombok.NoArgsConstructor;
 @Entity
 public class BallotTopic extends BaseEntity {
 
-    @Column
-    private String topic;
+    @Column private String topic;
 
-    @Column
-    private Long order;
+    @Column private Long order;
 
     @OneToMany(mappedBy = "ballotTopic", cascade = CascadeType.ALL)
     private List<BallotItem> ballotItems = new ArrayList<>();

--- a/src/main/java/com/team/piickle/card/category/domain/Category.java
+++ b/src/main/java/com/team/piickle/card/category/domain/Category.java
@@ -18,16 +18,16 @@ import lombok.NoArgsConstructor;
 @Entity
 public class Category extends BaseEntity {
 
-    @Column(name = "TITLE")
+    @Column
     private String title;
 
-    @Column(name = "CONTENT")
+    @Column
     private String content;
 
-    @Column(name = "GRADATION")
+    @Column
     private String gradation;
 
-    @Column(name = "EMOJI")
+    @Column
     private String emoji;
 
     @OneToMany(mappedBy = "category", cascade = CascadeType.ALL)

--- a/src/main/java/com/team/piickle/card/category/domain/Category.java
+++ b/src/main/java/com/team/piickle/card/category/domain/Category.java
@@ -18,17 +18,13 @@ import lombok.NoArgsConstructor;
 @Entity
 public class Category extends BaseEntity {
 
-    @Column
-    private String title;
+    @Column private String title;
 
-    @Column
-    private String content;
+    @Column private String content;
 
-    @Column
-    private String gradation;
+    @Column private String gradation;
 
-    @Column
-    private String emoji;
+    @Column private String emoji;
 
     @OneToMany(mappedBy = "category", cascade = CascadeType.ALL)
     private List<CardCategory> cards = new ArrayList<>();

--- a/src/main/java/com/team/piickle/card/domain/Card.java
+++ b/src/main/java/com/team/piickle/card/domain/Card.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 @AttributeOverride(name = "id", column = @Column(name = "CARD_ID"))
 @Entity
 public class Card extends BaseEntity {
-    @Column(name = "CONTENT")
+    @Column
     private String content;
 
     @OneToMany(mappedBy = "card", cascade = CascadeType.ALL)

--- a/src/main/java/com/team/piickle/card/domain/Card.java
+++ b/src/main/java/com/team/piickle/card/domain/Card.java
@@ -15,8 +15,7 @@ import lombok.NoArgsConstructor;
 @AttributeOverride(name = "id", column = @Column(name = "CARD_ID"))
 @Entity
 public class Card extends BaseEntity {
-    @Column
-    private String content;
+    @Column private String content;
 
     @OneToMany(mappedBy = "card", cascade = CascadeType.ALL)
     private List<CardFilter> filters = new ArrayList<>();

--- a/src/main/java/com/team/piickle/card/filter/Filter.java
+++ b/src/main/java/com/team/piickle/card/filter/Filter.java
@@ -14,6 +14,6 @@ import lombok.NoArgsConstructor;
 @Entity
 public class Filter extends BaseEntity {
 
-    @Column(name = "CONTENT")
+    @Column
     private String content;
 }

--- a/src/main/java/com/team/piickle/card/filter/Filter.java
+++ b/src/main/java/com/team/piickle/card/filter/Filter.java
@@ -14,6 +14,5 @@ import lombok.NoArgsConstructor;
 @Entity
 public class Filter extends BaseEntity {
 
-    @Column
-    private String content;
+    @Column private String content;
 }

--- a/src/main/java/com/team/piickle/card/tag/Tag.java
+++ b/src/main/java/com/team/piickle/card/tag/Tag.java
@@ -14,6 +14,6 @@ import lombok.NoArgsConstructor;
 @Entity
 public class Tag extends BaseEntity {
 
-    @Column(name = "CONTENT")
+    @Column
     private String content;
 }

--- a/src/main/java/com/team/piickle/card/tag/Tag.java
+++ b/src/main/java/com/team/piickle/card/tag/Tag.java
@@ -14,6 +14,5 @@ import lombok.NoArgsConstructor;
 @Entity
 public class Tag extends BaseEntity {
 
-    @Column
-    private String content;
+    @Column private String content;
 }

--- a/src/main/java/com/team/piickle/common/domain/BaseEntity.java
+++ b/src/main/java/com/team/piickle/common/domain/BaseEntity.java
@@ -23,13 +23,9 @@ public class BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @CreatedDate
-    @Column
-    private LocalDateTime createdAt;
+    @CreatedDate @Column private LocalDateTime createdAt;
 
-    @LastModifiedDate
-    @Column
-    private LocalDateTime updatedAt;
+    @LastModifiedDate @Column private LocalDateTime updatedAt;
 
     protected BaseEntity(Long id, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;

--- a/src/main/java/com/team/piickle/common/domain/BaseEntity.java
+++ b/src/main/java/com/team/piickle/common/domain/BaseEntity.java
@@ -24,11 +24,11 @@ public class BaseEntity {
     private Long id;
 
     @CreatedDate
-    @Column(name = "CREATED_AT")
+    @Column
     private LocalDateTime createdAt;
 
     @LastModifiedDate
-    @Column(name = "UPDATED_AT")
+    @Column
     private LocalDateTime updatedAt;
 
     protected BaseEntity(Long id, LocalDateTime createdAt, LocalDateTime updatedAt) {

--- a/src/main/java/com/team/piickle/config/CamelCaseToUnderscoresWithUpperCasesNamingStrategy.java
+++ b/src/main/java/com/team/piickle/config/CamelCaseToUnderscoresWithUpperCasesNamingStrategy.java
@@ -7,74 +7,74 @@ import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 
 public class CamelCaseToUnderscoresWithUpperCasesNamingStrategy implements PhysicalNamingStrategy {
 
-	@Override
-	public Identifier toPhysicalCatalogName(Identifier name, JdbcEnvironment jdbcEnvironment) {
-		return apply( name, jdbcEnvironment );
-	}
+    @Override
+    public Identifier toPhysicalCatalogName(Identifier name, JdbcEnvironment jdbcEnvironment) {
+        return apply(name, jdbcEnvironment);
+    }
 
-	@Override
-	public Identifier toPhysicalSchemaName(Identifier name, JdbcEnvironment jdbcEnvironment) {
-		return apply( name, jdbcEnvironment );
-	}
+    @Override
+    public Identifier toPhysicalSchemaName(Identifier name, JdbcEnvironment jdbcEnvironment) {
+        return apply(name, jdbcEnvironment);
+    }
 
-	@Override
-	public Identifier toPhysicalTableName(Identifier name, JdbcEnvironment jdbcEnvironment) {
-		return apply( name, jdbcEnvironment );
-	}
+    @Override
+    public Identifier toPhysicalTableName(Identifier name, JdbcEnvironment jdbcEnvironment) {
+        return apply(name, jdbcEnvironment);
+    }
 
-	@Override
-	public Identifier toPhysicalSequenceName(Identifier name, JdbcEnvironment jdbcEnvironment) {
-		return apply( name, jdbcEnvironment );
-	}
+    @Override
+    public Identifier toPhysicalSequenceName(Identifier name, JdbcEnvironment jdbcEnvironment) {
+        return apply(name, jdbcEnvironment);
+    }
 
-	@Override
-	public Identifier toPhysicalColumnName(Identifier name, JdbcEnvironment jdbcEnvironment) {
-		return apply( name, jdbcEnvironment );
-	}
+    @Override
+    public Identifier toPhysicalColumnName(Identifier name, JdbcEnvironment jdbcEnvironment) {
+        return apply(name, jdbcEnvironment);
+    }
 
-	private Identifier apply(final Identifier name, final JdbcEnvironment jdbcEnvironment) {
-		if ( name == null ) {
-			return null;
-		}
-		StringBuilder builder = new StringBuilder( name.getText().replace( '.', '_' ) );
-		for ( int i = 1; i < builder.length() - 1; i++ ) {
-			if ( isUnderscoreRequired( builder.charAt( i - 1 ), builder.charAt( i ), builder.charAt( i + 1 ) ) ) {
-				builder.insert( i++, '_' );
-			}
-		}
-		return getIdentifier( builder.toString(), name.isQuoted(), jdbcEnvironment );
-	}
+    private Identifier apply(final Identifier name, final JdbcEnvironment jdbcEnvironment) {
+        if (name == null) {
+            return null;
+        }
+        StringBuilder builder = new StringBuilder(name.getText().replace('.', '_'));
+        for (int i = 1; i < builder.length() - 1; i++) {
+            if (isUnderscoreRequired(builder.charAt(i - 1), builder.charAt(i), builder.charAt(i + 1))) {
+                builder.insert(i++, '_');
+            }
+        }
+        return getIdentifier(builder.toString(), name.isQuoted(), jdbcEnvironment);
+    }
 
-	/**
-	 * Get an identifier for the specified details. By default this method will return an identifier
-	 * with the name adapted based on the result of {@link #isCaseInsensitive(JdbcEnvironment)}
-	 *
-	 * @param name the name of the identifier
-	 * @param quoted if the identifier is quoted
-	 * @param jdbcEnvironment the JDBC environment
-	 *
-	 * @return an identifier instance
-	 */
-	protected Identifier getIdentifier(String name, final boolean quoted, final JdbcEnvironment jdbcEnvironment) {
-		if ( isCaseInsensitive( jdbcEnvironment ) ) {
-			name = name.toUpperCase( Locale.ROOT );
-		}
-		return new Identifier( name, quoted );
-	}
+    /**
+     * Get an identifier for the specified details. By default this method will return an identifier
+     * with the name adapted based on the result of {@link #isCaseInsensitive(JdbcEnvironment)}
+     *
+     * @param name the name of the identifier
+     * @param quoted if the identifier is quoted
+     * @param jdbcEnvironment the JDBC environment
+     * @return an identifier instance
+     */
+    protected Identifier getIdentifier(
+            String name, final boolean quoted, final JdbcEnvironment jdbcEnvironment) {
+        if (isCaseInsensitive(jdbcEnvironment)) {
+            name = name.toUpperCase(Locale.ROOT);
+        }
+        return new Identifier(name, quoted);
+    }
 
-	/**
-	 * Specify whether the database is case sensitive.
-	 *
-	 * @param jdbcEnvironment the JDBC environment which can be used to determine case
-	 *
-	 * @return true if the database is case insensitive sensitivity
-	 */
-	protected boolean isCaseInsensitive(JdbcEnvironment jdbcEnvironment) {
-		return true;
-	}
+    /**
+     * Specify whether the database is case sensitive.
+     *
+     * @param jdbcEnvironment the JDBC environment which can be used to determine case
+     * @return true if the database is case insensitive sensitivity
+     */
+    protected boolean isCaseInsensitive(JdbcEnvironment jdbcEnvironment) {
+        return true;
+    }
 
-	private boolean isUnderscoreRequired(final char before, final char current, final char after) {
-		return Character.isLowerCase( before ) && Character.isUpperCase( current ) && Character.isLowerCase( after );
-	}
-
+    private boolean isUnderscoreRequired(final char before, final char current, final char after) {
+        return Character.isLowerCase(before)
+                && Character.isUpperCase(current)
+                && Character.isLowerCase(after);
+    }
 }

--- a/src/main/java/com/team/piickle/config/CamelCaseToUnderscoresWithUpperCasesNamingStrategy.java
+++ b/src/main/java/com/team/piickle/config/CamelCaseToUnderscoresWithUpperCasesNamingStrategy.java
@@ -1,0 +1,80 @@
+package com.team.piickle.config;
+
+import java.util.Locale;
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.naming.PhysicalNamingStrategy;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+
+public class CamelCaseToUnderscoresWithUpperCasesNamingStrategy implements PhysicalNamingStrategy {
+
+	@Override
+	public Identifier toPhysicalCatalogName(Identifier name, JdbcEnvironment jdbcEnvironment) {
+		return apply( name, jdbcEnvironment );
+	}
+
+	@Override
+	public Identifier toPhysicalSchemaName(Identifier name, JdbcEnvironment jdbcEnvironment) {
+		return apply( name, jdbcEnvironment );
+	}
+
+	@Override
+	public Identifier toPhysicalTableName(Identifier name, JdbcEnvironment jdbcEnvironment) {
+		return apply( name, jdbcEnvironment );
+	}
+
+	@Override
+	public Identifier toPhysicalSequenceName(Identifier name, JdbcEnvironment jdbcEnvironment) {
+		return apply( name, jdbcEnvironment );
+	}
+
+	@Override
+	public Identifier toPhysicalColumnName(Identifier name, JdbcEnvironment jdbcEnvironment) {
+		return apply( name, jdbcEnvironment );
+	}
+
+	private Identifier apply(final Identifier name, final JdbcEnvironment jdbcEnvironment) {
+		if ( name == null ) {
+			return null;
+		}
+		StringBuilder builder = new StringBuilder( name.getText().replace( '.', '_' ) );
+		for ( int i = 1; i < builder.length() - 1; i++ ) {
+			if ( isUnderscoreRequired( builder.charAt( i - 1 ), builder.charAt( i ), builder.charAt( i + 1 ) ) ) {
+				builder.insert( i++, '_' );
+			}
+		}
+		return getIdentifier( builder.toString(), name.isQuoted(), jdbcEnvironment );
+	}
+
+	/**
+	 * Get an identifier for the specified details. By default this method will return an identifier
+	 * with the name adapted based on the result of {@link #isCaseInsensitive(JdbcEnvironment)}
+	 *
+	 * @param name the name of the identifier
+	 * @param quoted if the identifier is quoted
+	 * @param jdbcEnvironment the JDBC environment
+	 *
+	 * @return an identifier instance
+	 */
+	protected Identifier getIdentifier(String name, final boolean quoted, final JdbcEnvironment jdbcEnvironment) {
+		if ( isCaseInsensitive( jdbcEnvironment ) ) {
+			name = name.toUpperCase( Locale.ROOT );
+		}
+		return new Identifier( name, quoted );
+	}
+
+	/**
+	 * Specify whether the database is case sensitive.
+	 *
+	 * @param jdbcEnvironment the JDBC environment which can be used to determine case
+	 *
+	 * @return true if the database is case insensitive sensitivity
+	 */
+	protected boolean isCaseInsensitive(JdbcEnvironment jdbcEnvironment) {
+		return true;
+	}
+
+	private boolean isUnderscoreRequired(final char before, final char current, final char after) {
+		return Character.isLowerCase( before ) && Character.isUpperCase( current ) && Character.isLowerCase( after );
+	}
+
+}

--- a/src/main/java/com/team/piickle/user/domain/User.java
+++ b/src/main/java/com/team/piickle/user/domain/User.java
@@ -16,23 +16,23 @@ import lombok.*;
 @Entity
 public class User extends BaseEntity {
 
-    @Column(name = "EMAIL")
+    @Column
     private String email;
 
-    @Column(name = "NAME")
+    @Column
     private String name;
 
-    @Column(name = "NICKNAME")
-    private String nickName;
+    @Column
+    private String nickname;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "GENDER", nullable = false)
     private GenderStatus gender;
 
-    @Column(name = "HASHED_PASSWORD")
+    @Column
     private String hashedPassword;
 
-    @Column(name = "PROFILE_IMAGE_URL")
+    @Column
     private String profileImageUrl;
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)

--- a/src/main/java/com/team/piickle/user/domain/User.java
+++ b/src/main/java/com/team/piickle/user/domain/User.java
@@ -16,24 +16,19 @@ import lombok.*;
 @Entity
 public class User extends BaseEntity {
 
-    @Column
-    private String email;
+    @Column private String email;
 
-    @Column
-    private String name;
+    @Column private String name;
 
-    @Column
-    private String nickname;
+    @Column private String nickname;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "GENDER", nullable = false)
     private GenderStatus gender;
 
-    @Column
-    private String hashedPassword;
+    @Column private String hashedPassword;
 
-    @Column
-    private String profileImageUrl;
+    @Column private String profileImageUrl;
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
     private List<Bookmark> bookmarks = new ArrayList<>();

--- a/src/main/resources/application-ky.yml
+++ b/src/main/resources/application-ky.yml
@@ -3,7 +3,7 @@ spring:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     database: mysql
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     show-sql: true
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,9 @@ jwt:
 
 spring:
   jpa:
-    hibernate.naming.physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+    hibernate:
+      naming:
+        physical-strategy: com.team.piickle.config.CamelCaseToUnderscoresWithUpperCasesNamingStrategy
 
 ---
 


### PR DESCRIPTION
**우선순위**
<!--
D-0 (ASAP)
긴급한 수정사항으로 바로 리뷰해 주세요.
앱의 오류로 인해 장애가 발생하거나, 빌드가 되지 않는 등 긴급 이슈가 발생할 때 사용합니다.
D-N (Within N days)
N일 이내에 리뷰해 주세요
-->

D-2



**변경사항**
- 하나 하나씩 변경하는 것이 앞으로 귀찮을 수도 있고 + 빼먹을 가능성이 있어서 강제적으로 변환하는 방법을 찾아보다가 하이버네이트 이름 규칙 전략을 구현해서 스프링 프로퍼티에서 설정해주었어요. 
- 저는 ImplicitNamingStrategy가 아닌 PhysicalNamingStrategy를 구현했습니다. [참고](https://www.baeldung.com/hibernate-naming-strategy)
- 그렇게 해서 불필요해진 이름 명시 코드를 제거해주었어요 ex. `@Column(name = "아무개..")`

**유의사항**
<!--
- 영향범위
- 중점적으로 pr 리뷰해줬으면 하는 부분
-->

- 만약에 코드 상에서 명시하는 이름이 있으면 그 이름으로 반영되는 것 확인했습니다 ㅎㅎ
- 대신 Physical naming strategy를 바꿔준거라서 uppercase로 무조건 변경됩니다... (이거 일단은 아무 문제 없는데 나중에 문제가 될까요?)

이런 식
<img width="1233" alt="image" src="https://user-images.githubusercontent.com/61582017/215717071-24323822-1c51-411c-814e-b3ddc5833e64.png">


**참조**
<!--
변경사항에 대해서 파악할 수 있는 링크 (노션, 슬랙, 위키 등)
-->